### PR TITLE
Use xenial for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_install:
   - git submodule update --init --recursive
 script:
   - bash -c 'shopt -s globstar; shellcheck ./*.sh; shellcheck ./tests/*.sh'
-  - bash tests/unit-tests.sh -skip
+  - bash tests/unit-tests.sh -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: generic
 sudo: required
 matrix:
   include:
-    - dist: trusty
+    - dist: xenial
       sudo: required
 # Use https (public access) instead of git for git-submodules. This modifies only Travis-CI behavior
 git:

--- a/setupLibrary.sh
+++ b/setupLibrary.sh
@@ -121,6 +121,11 @@ function configureNTP() {
     else
         sudo apt-get update
         sudo apt-get --assume-yes install ntp
+        
+        # force NTP to sync
+        sudo service ntp stop
+        sudo ntpd -gq
+        sudo service ntp start
     fi
 }
 

--- a/tests/unit-tests.sh
+++ b/tests/unit-tests.sh
@@ -2,9 +2,11 @@
 
 set -e
 
-while getopts "skip" opt; do
+while getopts "s" opt; do
     case $opt in
     s) SKIP_SETUP=true ;;
+    *) echo "usage: $0 [-v] [-r]" >&2
+       exit 1 ;;
     esac
 done
 


### PR DESCRIPTION
Use xenial (16.04) for travis as a lot of packages on trusty (14.04) are outdated.